### PR TITLE
Add MERN skeleton for Ansible UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,29 @@
 # AI_Project
+
+This repository contains a minimal skeleton for an Ansible Automation UI using the MERN stack with a placeholder for RAG and a local LLM.
+
+## Structure
+
+- `server/` – Express.js backend with sample routes.
+- `client/` – React frontend skeleton.
+- `kb/playbooks/` – Sample knowledge base files for RAG.
+
+## Getting Started
+
+1. **Install dependencies** (requires Node.js):
+   ```bash
+   cd server && npm install
+   ```
+   ```bash
+   cd ../client && npm install
+   ```
+2. **Run the backend**:
+   ```bash
+   npm start
+   ```
+3. **Run the frontend** (placeholder):
+   ```bash
+   npm start
+   ```
+
+This is a minimal setup intended as a starting point for further development.

--- a/client/package.json
+++ b/client/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "ansible-automation-ui",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "start": "echo \"Start client\"",
+    "test": "echo \"No tests\""
+  },
+  "dependencies": {
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
+  }
+}

--- a/client/public/index.html
+++ b/client/public/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Ansible UI</title>
+</head>
+<body>
+  <div id="root">React UI placeholder</div>
+</body>
+</html>

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -1,0 +1,1 @@
+console.log('React app placeholder');

--- a/kb/playbooks/sample.yaml
+++ b/kb/playbooks/sample.yaml
@@ -1,0 +1,4 @@
+- hosts: all
+  tasks:
+    - name: Placeholder
+      debug: msg="This is a sample playbook"

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "ansible-automation-backend",
+  "version": "0.1.0",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "test": "echo \"No tests\""
+  },
+  "dependencies": {
+    "express": "^4.18.2"
+  }
+}

--- a/server/server.js
+++ b/server/server.js
@@ -1,0 +1,22 @@
+const express = require('express');
+const app = express();
+app.use(express.json());
+
+app.post('/generate-playbook', (req, res) => {
+  const playbook = {
+    title: 'Linux Patching',
+    yaml: `- hosts: all\n  tasks:\n    - name: Example task\n      debug: msg="patching"`
+  };
+  res.json(playbook);
+});
+
+app.post('/run-playbook', (req, res) => {
+  res.json({ message: 'Playbook executed' });
+});
+
+app.post('/check-connectivity', (req, res) => {
+  res.json({ status: 'Connectivity OK' });
+});
+
+const port = process.env.PORT || 3001;
+app.listen(port, () => console.log(`Server running on port ${port}`));


### PR DESCRIPTION
## Summary
- add Express backend with sample routes for playbook generation and execution
- add simple React client placeholder
- include sample knowledge base playbook
- document project layout and basic commands

## Testing
- `npm test` in `server/`
- `npm test` in `client/`


------
https://chatgpt.com/codex/tasks/task_e_6851878697848326a3a09e4ded59f4fd