### PR TITLE
Highlight non-compliance in HTML report

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository contains a minimal skeleton for an Ansible Automation UI using t
 
 - `server/` – Express.js backend with sample routes.
 - `client/` – React frontend skeleton.
-- `kb/playbooks/` – Sample knowledge base files for RAG.
+- `kb/playbooks/` – Sample knowledge base files for RAG and example Ansible playbooks.
 
 ## Getting Started
 
@@ -27,3 +27,14 @@ This repository contains a minimal skeleton for an Ansible Automation UI using t
    ```
 
 This is a minimal setup intended as a starting point for further development.
+
+The Ansible playbooks themselves do not require Node.js. Running `ansible-playbook
+kb/playbooks/cis_compliance.yml` will generate `compliance_report.html`
+without the UI components.
+
+## Example Playbook
+
+The `kb/playbooks/cis_compliance.yml` playbook demonstrates how to collect
+CIS benchmark results for RHEL 8, ESXi 8 and Windows Server 2019 and generate a
+simple HTML compliance report. Non-compliant results are highlighted in red in
+the report.

--- a/kb/playbooks/cis_compliance.yml
+++ b/kb/playbooks/cis_compliance.yml
@@ -1,0 +1,32 @@
+- hosts: all
+  gather_facts: yes
+  vars:
+    compliance_results: []
+  tasks:
+    - name: Determine operating system
+      set_fact:
+        os_family: "{{ ansible_facts['os_family'] | lower }}"
+
+    - name: Include OS specific CIS checks
+      include_tasks:
+        file: "{{ lookup('first_found', params) }}"
+      vars:
+        params:
+          files:
+            - "{{ os_family }}-cis.yml"
+            - default-cis.yml
+
+    - name: Collect compliance result for host
+      set_fact:
+        compliance_results: "{{ compliance_results + [ { 'host': inventory_hostname, 'compliant': compliance_score.compliant | default(0), 'non_compliant': compliance_score.non_compliant | default(0) } ] }}"
+
+  post_tasks:
+    - name: Calculate consolidated counts
+      set_fact:
+        total_compliant: "{{ compliance_results | sum(attribute='compliant') }}"
+        total_noncompliant: "{{ compliance_results | sum(attribute='non_compliant') }}"
+
+    - name: Generate HTML report
+      template:
+        src: report.html.j2
+        dest: compliance_report.html

--- a/kb/playbooks/default-cis.yml
+++ b/kb/playbooks/default-cis.yml
@@ -1,0 +1,8 @@
+- name: Unsupported platform
+  debug:
+    msg: "CIS benchmark not implemented for this platform"
+- name: Set default compliance score
+  set_fact:
+    compliance_score:
+      compliant: 0
+      non_compliant: 0

--- a/kb/playbooks/redhat-cis.yml
+++ b/kb/playbooks/redhat-cis.yml
@@ -1,0 +1,14 @@
+- name: RHEL 8 CIS checks
+  block:
+    - name: Placeholder - check CIS controls
+      command: echo "Check RHEL8 CIS"
+      register: rhel_cis_result
+
+    - name: Placeholder - fix CIS controls
+      command: echo "Fix RHEL8 CIS"
+
+    - name: Set compliance score
+      set_fact:
+        compliance_score:
+          compliant: 1  # placeholder
+          non_compliant: 0

--- a/kb/playbooks/report.html.j2
+++ b/kb/playbooks/report.html.j2
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>CIS Compliance Report</title>
+</head>
+<body>
+  <h1>CIS Compliance Summary</h1>
+  <p>Compliant: {{ total_compliant }}</p>
+  <p style="color: red;">Non-Compliant: {{ total_noncompliant }}</p>
+  <table border="1" cellpadding="5" cellspacing="0">
+    <tr>
+      <th>Host</th>
+      <th>Compliant</th>
+      <th>Non-Compliant</th>
+    </tr>
+    {% for item in compliance_results %}
+    <tr>
+      <td>{{ item.host }}</td>
+      <td>{{ item.compliant }}</td>
+      <td{% if item.non_compliant|int > 0 %} style="color: red;"{% endif %}>{{ item.non_compliant }}</td>
+    </tr>
+    {% endfor %}
+  </table>
+</body>
+</html>

--- a/kb/playbooks/vmware-cis.yml
+++ b/kb/playbooks/vmware-cis.yml
@@ -1,0 +1,14 @@
+- name: ESXi 8 CIS checks
+  block:
+    - name: Placeholder - check CIS controls
+      command: echo "Check ESXi8 CIS"
+      register: esxi_cis_result
+
+    - name: Placeholder - fix CIS controls
+      command: echo "Fix ESXi8 CIS"
+
+    - name: Set compliance score
+      set_fact:
+        compliance_score:
+          compliant: 1  # placeholder
+          non_compliant: 0

--- a/kb/playbooks/windows-cis.yml
+++ b/kb/playbooks/windows-cis.yml
@@ -1,0 +1,14 @@
+- name: Windows Server 2019 CIS checks
+  block:
+    - name: Placeholder - check CIS controls
+      win_shell: echo "Check Windows 2019 CIS"
+      register: win_cis_result
+
+    - name: Placeholder - fix CIS controls
+      win_shell: echo "Fix Windows 2019 CIS"
+
+    - name: Set compliance score
+      set_fact:
+        compliance_score:
+          compliant: 1  # placeholder
+          non_compliant: 0


### PR DESCRIPTION
## Summary
- emphasize non-compliant counts in the generated HTML report
- mention that non-compliant results appear in red
- note that Node.js is not required for running the playbooks
- add placeholder fix tasks for each OS-specific playbook

## Testing
- `npm test` in `server`
- `npm test` in `client`


------
https://chatgpt.com/codex/tasks/task_e_6851972f936c832688ffbe3538beeb5c